### PR TITLE
Add popup window and save to read later

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ A very minimal Firefox extension for [Pinboard](https://pinboard.in) that doesn'
 
 The Pinboard Button opens a small menu that let's you:
 
-- Save the current page to Pinboard
+- Save the current page to your Pinboard
+- Save the current page to your Pinboard's "to read" list
 - Open your unread Pinboard bookmarks
 - Open all your Pinboard bookmarks
 
-The extension also has a keyboard shortcut to quickly save to Pinboard: `Alt+P`.
+The extension also provides keyboard shortcuts to:
+
+- Save to Pinboard: `Alt+P`.
+- Save to Read Later: `Alt+R`.
 
 [Download](https://addons.mozilla.org/en-US/firefox/addon/pinboard-button/) it in the Firefox Add-ons website.

--- a/background.js
+++ b/background.js
@@ -1,7 +1,10 @@
-/* global browser, saveToPinboard */
+/* global browser, saveToPinboard, saveToReadLater */
 
 browser.commands.onCommand.addListener(function (command) {
   if (command == "save-to-pinboard") {
     saveToPinboard()
+  }
+  if (command == "save-to-read-later") {
+    saveToReadLater()
   }
 })

--- a/helpers.js
+++ b/helpers.js
@@ -5,7 +5,7 @@
 const BASE_URL = 'https://pinboard.in'
 
 function saveToPinboard (toReadLater) {
-  if (toReadLater === null) toReadLater = false
+  if (toReadLater === undefined) toReadLater = false
 
   browser.tabs.query({active: true, currentWindow: true}, function (tabs) {
     let tab = tabs[0]
@@ -14,7 +14,6 @@ function saveToPinboard (toReadLater) {
     let title = tab.title
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
-
     let next = encodeURIComponent(BASE_URL)
 
     let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +

--- a/helpers.js
+++ b/helpers.js
@@ -4,7 +4,9 @@
 
 const BASE_URL = 'https://pinboard.in'
 
-function saveToPinboard () {
+function saveToPinboard (toReadLater) {
+  if (toReadLater === null) toReadLater = false
+
   browser.tabs.query({active: true, currentWindow: true}, function (tabs) {
     let tab = tabs[0]
 
@@ -13,22 +15,41 @@ function saveToPinboard () {
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
 
-    let fullUrl = pinboardUrl + 'showtags=yes' + '&url=' + encodeURIComponent(url) +
+    let next = encodeURIComponent(BASE_URL)
+
+    let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +
+      '&url=' + encodeURIComponent(url) +
       '&description=' + encodeURIComponent(description) +
       '&title=' + encodeURIComponent(title)
 
-    browser.tabs.create({
+    if (toReadLater) {
+      // add URL to Pinboard's "to read" list, without asking for description and tags
+      fullUrl = pinboardUrl + 'later=yes&noui=yes&next=' + next +
+        '&url=' + encodeURIComponent(url) +
+        '&title=' + encodeURIComponent(title)
+    }
+
+    browser.windows.create({
       url: fullUrl,
-      index: tab.index + 1,
-      active: true
+      width: 720,
+      height: 540,
+      type: "popup"
     })
   })
 }
 
+function saveToReadLater () {
+  saveToPinboard(true)
+}
+
 function unreadBookmarks () {
-  window.open(BASE_URL + '/toread/')
+  browser.tabs.create({
+    url: BASE_URL + '/toread/'
+  })
 }
 
 function allBookmarks () {
-  window.open(BASE_URL)
+  browser.tabs.create({
+    url: BASE_URL
+  })
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "A minimal Firefox extension for Pinboard (https://pinboard.in) that doesn't use API keys, but just opens Pinboard windows.",
   "homepage_url": "https://github.com/fiatjaf/firefox-pinboard-popup/",
   "manifest_version": 2,
-  "version" : "0.3.0",
+  "version" : "0.4.0",
   "applications": {
     "gecko": {
       "id": "{eb059682-fdfe-4250-a2c2-7f7d1af4fe85}"
@@ -23,6 +23,10 @@
     "save-to-pinboard": {
       "suggested_key": { "default": "Alt+P" },
       "description": "Save current page to Pinboard"
+    },
+    "save-to-read-later": {
+      "suggested_key": { "default": "Alt+R" },
+      "description": "Save current page to Pinboard's \"to read\" list"
     }
   },
   "browser_action": {

--- a/popup.html
+++ b/popup.html
@@ -6,10 +6,11 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
     font-size: 13px;
     font-weight: normal;
-    line-height: 1;
+    line-height: 1em;
     border-radius: 5px;
     cursor:default;
     position: relative;
+    width: 180px;
 }
 
 .border {
@@ -23,22 +24,22 @@
 }
 
 .item .shortcut {
-  font-size: 0.7em;
-  text-transform: uppercase;
-  position: relative;
+  float: right;
   display: inline-block;
   margin-left: 1em;
-  opacity: 0.5;
+  padding: 0.2em 0.4em;
+  border-radius: 0.2em;
   background: black;
   color: white;
-  padding: 0.15em 0.4em;
-  border-radius: .2em;
-  position: relative;
-  bottom: 0.1em;
+  opacity: 0.5;
+  font-size: 0.7em;
+  line-height: 1em;
+  text-transform: uppercase;
 }
 </style>
 
 <div id="saveToPinboard" class="item">Save to Pinboard <span class="shortcut">Alt+P</span></div>
+<div id="saveToReadLater" class="item">Save to Read Later <span class="shortcut">Alt+R</span></div>
 <div id="unreadBookmarks" class="item">Unread bookmarks</div>
 <div id="allBookmarks" class="item">All bookmarks</div>
 

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 /* eslint-env browser */
-/* global saveToPinboard, unreadBookmarks, allBookmarks */
+/* global saveToPinboard, saveToReadLater, unreadBookmarks, allBookmarks */
 
 document.getElementById('saveToPinboard').addEventListener('click', saveToPinboard)
+document.getElementById('saveToReadLater').addEventListener('click', saveToReadLater)
 document.getElementById('unreadBookmarks').addEventListener('click', unreadBookmarks)
 document.getElementById('allBookmarks').addEventListener('click', allBookmarks)


### PR DESCRIPTION
- New: Option to save current page to Pinboard's "to read" list
- Change: When saving to Pinboard, open its URL in a popup window
instead of opening it in a new tab
- Change: Open "All bookmarks" and "Unread bookmarks" in tabs instead of
windows
- Change: After saving to Pinboard, redirect to Pinboard home instead of
displaying a blank page