### PR TITLE
close popup after the job is done.

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,4 +7,10 @@ browser.commands.onCommand.addListener(function (command) {
   if (command == "save-to-read-later") {
     saveToReadLater()
   }
+
+  browser.runtime.onMessage.addListener(function (message, sender) {
+    if (message === 'close-this') {
+      browser.windows.remove(sender.tab.windowId)
+    }
+  })
 })

--- a/close.js
+++ b/close.js
@@ -1,0 +1,3 @@
+/* global browser */
+
+browser.runtime.sendMessage('close-this')

--- a/helpers.js
+++ b/helpers.js
@@ -14,7 +14,7 @@ function saveToPinboard (toReadLater) {
     let title = tab.title
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
-    let next = encodeURIComponent(BASE_URL)
+    let next = encodeURIComponent(BASE_URL + '/close')
 
     let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +
       '&url=' + encodeURIComponent(url) +
@@ -32,7 +32,7 @@ function saveToPinboard (toReadLater) {
       url: fullUrl,
       width: 720,
       height: 540,
-      type: "popup"
+      type: 'popup'
     })
   })
 }

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   },
   "permissions": [
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "https://pinboard.in/close"
   ],
   "background": {
     "scripts": [
@@ -29,6 +30,10 @@
       "description": "Save current page to Pinboard's \"to read\" list"
     }
   },
+  "content_scripts": [{
+    "matches": ["https://pinboard.in/close"],
+    "js": ["close.js"]
+  }],
   "browser_action": {
     "default_title": "Pinboard",
     "default_popup": "popup.html",


### PR DESCRIPTION
Instead of redirecting to the Pinboard dashboard, redirect to `pinboard.in/close`, a page that doesn't exist, but nonetheless will trigger a content-script, `close.js`, that will send a message to `background.js` which will then invoke `browser.windows.remove()` to close the popup window.