### PR TITLE
V0.4.1

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,4 +7,10 @@ browser.commands.onCommand.addListener(function (command) {
   if (command == "save-to-read-later") {
     saveToReadLater()
   }
+
+  browser.runtime.onMessage.addListener(function (message, sender) {
+    if (message === 'close-this') {
+      browser.windows.remove(sender.tab.windowId)
+    }
+  })
 })

--- a/background.js
+++ b/background.js
@@ -1,16 +1,16 @@
 /* global browser, saveToPinboard, saveToReadLater */
 
 browser.commands.onCommand.addListener(function (command) {
-  if (command == "save-to-pinboard") {
+  if (command == 'save-to-pinboard') {
     saveToPinboard()
   }
-  if (command == "save-to-read-later") {
+  if (command == 'save-to-read-later') {
     saveToReadLater()
   }
+})
 
-  browser.runtime.onMessage.addListener(function (message, sender) {
-    if (message === 'close-this') {
-      browser.windows.remove(sender.tab.windowId)
-    }
-  })
+browser.runtime.onMessage.addListener(function (message, sender) {
+  if (message === 'close-this') {
+    browser.windows.remove(sender.tab.windowId)
+  }
 })

--- a/close.js
+++ b/close.js
@@ -1,0 +1,3 @@
+/* global browser */
+
+browser.runtime.sendMessage('close-this')

--- a/helpers.js
+++ b/helpers.js
@@ -5,7 +5,7 @@
 const BASE_URL = 'https://pinboard.in'
 
 function saveToPinboard (toReadLater) {
-  if (toReadLater === undefined) toReadLater = false
+  if (toReadLater !== true) toReadLater = false
 
   browser.tabs.query({active: true, currentWindow: true}, function (tabs) {
     let tab = tabs[0]
@@ -16,7 +16,7 @@ function saveToPinboard (toReadLater) {
     let pinboardUrl = BASE_URL + '/add?'
     let next = encodeURIComponent(BASE_URL + '/close')
 
-    let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +
+    let fullUrl = pinboardUrl + 'next=' + next +
       '&url=' + encodeURIComponent(url) +
       '&description=' + encodeURIComponent(description) +
       '&title=' + encodeURIComponent(title)
@@ -30,8 +30,8 @@ function saveToPinboard (toReadLater) {
 
     browser.windows.create({
       url: fullUrl,
-      width: 720,
-      height: 540,
+      width: 660,
+      height: 300,
       type: 'popup'
     })
   })

--- a/helpers.js
+++ b/helpers.js
@@ -14,7 +14,7 @@ function saveToPinboard (toReadLater) {
     let title = tab.title
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
-    let next = encodeURIComponent(BASE_URL)
+    let next = encodeURIComponent(BASE_URL + '/close')
 
     let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +
       '&url=' + encodeURIComponent(url) +
@@ -32,7 +32,7 @@ function saveToPinboard (toReadLater) {
       url: fullUrl,
       width: 720,
       height: 540,
-      type: "popup"
+      type: 'popup'
     })
   })
 }

--- a/helpers.js
+++ b/helpers.js
@@ -5,7 +5,7 @@
 const BASE_URL = 'https://pinboard.in'
 
 function saveToPinboard (toReadLater) {
-  if (toReadLater === null) toReadLater = false
+  if (toReadLater === undefined) toReadLater = false
 
   browser.tabs.query({active: true, currentWindow: true}, function (tabs) {
     let tab = tabs[0]
@@ -14,7 +14,6 @@ function saveToPinboard (toReadLater) {
     let title = tab.title
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
-
     let next = encodeURIComponent(BASE_URL)
 
     let fullUrl = pinboardUrl + 'showtags=yes&next=' + next +

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "A minimal Firefox extension for Pinboard (https://pinboard.in) that doesn't use API keys, but just opens Pinboard windows.",
   "homepage_url": "https://github.com/fiatjaf/firefox-pinboard-popup/",
   "manifest_version": 2,
-  "version" : "0.4.0",
+  "version" : "0.4.1",
   "applications": {
     "gecko": {
       "id": "{eb059682-fdfe-4250-a2c2-7f7d1af4fe85}"

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   },
   "permissions": [
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "https://pinboard.in/close"
   ],
   "background": {
     "scripts": [
@@ -29,6 +30,10 @@
       "description": "Save current page to Pinboard's \"to read\" list"
     }
   },
+  "content_scripts": [{
+    "matches": ["https://pinboard.in/close"],
+    "js": ["close.js"]
+  }],
   "browser_action": {
     "default_title": "Pinboard",
     "default_popup": "popup.html",


### PR DESCRIPTION
Hi, Giovanni.

I was busy these days and could not answer your questions on the previous pull request.

There is really a bug in the "Save to Pinboard" option from the menu. If you click on that option, it will save the page as a read later bookmark. I fixed this issue in this commit.

I also fixed the code that should close the popup after saving the bookmark. But, although this is working, it brings a new problem into scene: if the user is not logged in, Pinboard still redirects to `/close`; so even when failing to save the bookmark, the popup is automatically closed and the user will have no idea the process failed.

For now I'm going to publish this fix and open an issue regarding the scenario I explained above, then we can investigate a better solution afterwards.