### PR TITLE
use relative "/close" on ?next=

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -14,7 +14,7 @@ function saveToPinboard (toReadLater) {
     let title = tab.title
     let description = tab.description || ''
     let pinboardUrl = BASE_URL + '/add?'
-    let next = encodeURIComponent(BASE_URL + '/close')
+    let next = encodeURIComponent('/close')
 
     let fullUrl = pinboardUrl + 'next=' + next +
       '&url=' + encodeURIComponent(url) +

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "description": "A minimal Firefox extension for Pinboard (https://pinboard.in) that doesn't use API keys, but just opens Pinboard windows.",
   "homepage_url": "https://github.com/fiatjaf/firefox-pinboard-popup/",
   "manifest_version": 2,
-  "version" : "0.4.1",
+  "version" : "0.4.2",
   "applications": {
     "gecko": {
       "id": "{eb059682-fdfe-4250-a2c2-7f7d1af4fe85}"


### PR DESCRIPTION
Apparently, fixes https://github.com/fiatjaf/firefox-pinboard/issues/6

(Actually, I haven't tested this on the extension, but it works when manually building the `pinboard.in/add` URLs.)